### PR TITLE
Implement API server

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,6 +134,28 @@ It uses a color-coded interface for clarity.
 It provides an advanced multi-select menu for choosing style descriptors using your arrow keys and spacebar.
 After you've answered all the questions, it will display the final command for your review.
 You can then confirm to execute it directly or cancel and copy the command for manual use.
+## API Server
+
+Mapperatorinator includes a small FastAPI server for programmatic generation. You can run it directly or via Docker Compose.
+
+```sh
+python api_server.py
+```
+
+To run inside Docker, use:
+
+```sh
+docker compose up api
+```
+
+### Endpoints
+
+- `POST /api/infer` – start a new inference job. Supply parameters such as `audio_path`, `beatmap_path` and `model` in JSON. The response returns a `job_id`.
+- `GET /api/progress/<job_id>` – stream progress logs using Server-Sent Events.
+- `GET /api/download/<job_id>` – download the resulting `.osz` file once the job completes.
+
+This server wraps `inference.py` and mirrors the options available in the CLI. FastAPI automatically exposes interactive documentation at `/docs` once the server is running.
+
 
 ## Generation Tips
 

--- a/api_server.py
+++ b/api_server.py
@@ -1,0 +1,99 @@
+import os
+import sys
+import uuid
+import subprocess
+import threading
+import queue
+import asyncio
+
+from fastapi import FastAPI, HTTPException
+from fastapi.responses import StreamingResponse, FileResponse
+from pydantic import BaseModel
+from sse_starlette.sse import EventSourceResponse
+
+app = FastAPI(title="Mapperatorinator API")
+
+class Job:
+    def __init__(self, cmd: list[str], work_dir: str):
+        self.id = uuid.uuid4().hex
+        self.work_dir = work_dir
+        os.makedirs(work_dir, exist_ok=True)
+        self.process = subprocess.Popen(
+            cmd,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.STDOUT,
+            universal_newlines=True,
+            bufsize=1,
+        )
+        self.queue: queue.Queue[str | None] = queue.Queue()
+        self.output_file: str | None = None
+        self.thread = threading.Thread(target=self._collect_output, daemon=True)
+        self.thread.start()
+
+    def _collect_output(self) -> None:
+        assert self.process.stdout is not None
+        for line in iter(self.process.stdout.readline, ""):
+            self.queue.put(line)
+            if "Generated .osz saved to" in line:
+                self.output_file = line.strip().split(" to ")[-1]
+        self.process.stdout.close()
+        self.process.wait()
+        self.queue.put(None)
+
+jobs: dict[str, Job] = {}
+
+class InferRequest(BaseModel):
+    audio_path: str
+    beatmap_path: str | None = None
+    model: str = "v30"
+    export_osz: bool = True
+
+@app.post("/api/infer")
+def start_inference(req: InferRequest):
+    work_dir = os.path.abspath(os.path.join("outputs", uuid.uuid4().hex))
+    cmd = [
+        sys.executable,
+        "inference.py",
+        "-cn",
+        req.model,
+        f"audio_path={req.audio_path}",
+        f"output_path={work_dir}",
+    ]
+    if req.beatmap_path:
+        cmd.append(f"beatmap_path={req.beatmap_path}")
+    cmd.append("export_osz=true" if req.export_osz else "export_osz=false")
+
+    job = Job(cmd, work_dir)
+    jobs[job.id] = job
+    return {"job_id": job.id}
+
+@app.get("/api/progress/{job_id}")
+async def progress(job_id: str):
+    job = jobs.get(job_id)
+    if not job:
+        raise HTTPException(status_code=404, detail="job not found")
+
+    async def event_generator():
+        while True:
+            line = await asyncio.to_thread(job.queue.get)
+            if line is None:
+                break
+            yield {"data": line}
+
+    return EventSourceResponse(event_generator())
+
+@app.get("/api/download/{job_id}")
+def download(job_id: str):
+    job = jobs.get(job_id)
+    if not job:
+        raise HTTPException(status_code=404, detail="job not found")
+    if job.output_file and os.path.exists(job.output_file):
+        return FileResponse(job.output_file, filename=os.path.basename(job.output_file), media_type="application/octet-stream")
+    if job.process.poll() is None:
+        raise HTTPException(status_code=409, detail="job not finished")
+    raise HTTPException(status_code=404, detail="output not found")
+
+if __name__ == "__main__":
+    import uvicorn
+    uvicorn.run(app, host="0.0.0.0", port=5005)
+

--- a/compose.yaml
+++ b/compose.yaml
@@ -23,3 +23,26 @@ services:
         environment:
           - PROJECT_PATH=/workspace/Mapperatorinator
           - WANDB_API_KEY=${WANDB_API_KEY}
+
+    api:
+        build: .
+        command: uvicorn api_server:app --host 0.0.0.0 --port 5005
+        container_name: mapperatorinator_api
+        volumes:
+        - .:/workspace/Mapperatorinator
+        - ../datasets:/workspace/datasets
+        network_mode: host
+        shm_size: 8gb
+        deploy:
+            resources:
+                reservations:
+                    devices:
+                        - driver: nvidia
+                          count: all
+                          capabilities:
+                              - gpu
+        environment:
+          - PROJECT_PATH=/workspace/Mapperatorinator
+          - WANDB_API_KEY=${WANDB_API_KEY}
+        ports:
+          - "5005:5005"

--- a/requirements.txt
+++ b/requirements.txt
@@ -16,4 +16,7 @@ lightning
 pywebview[qt]
 pyqtwebengine
 flask
+fastapi
+uvicorn
+sse-starlette
 audioop-lts; python_version>='3.13'


### PR DESCRIPTION
## Summary
- add `api_server.py` using FastAPI instead of Flask
- add FastAPI, uvicorn, and SSE dependencies
- document the FastAPI server and how to run it with Docker Compose
- update compose file with an `api` service

## Testing
- `python -m py_compile api_server.py`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'numpy')*

------
https://chatgpt.com/codex/tasks/task_e_6876b2b33eb08331a68428071834902a